### PR TITLE
Restrict scheme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.0.3
 - Fixes checking of files when no folder was open.
+- Prevents virtual files, including those from the git scm provider, from being checked. (Fixes [#2](https://github.com/adamvoss/vscode-languagetool/issues/2))
 
 ## 0.0.2
 - Allows any LanguageTool supported language to be used through the use of supplemental extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.0.3
+- Fixes checking of files when no folder was open.
+
 ## 0.0.2
 - Allows any LanguageTool supported language to be used through the use of supplemental extensions
 - Removes built-in English support

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,16 +75,23 @@ export function activate(context: ExtensionContext) {
 				let process = child_process.spawn(newScript, [server.address().port.toString()], options);
 
 				// Send raw output to a file
-				if (!fs.existsSync(context.storagePath))
-					fs.mkdirSync(context.storagePath);
+				if (context.storagePath) {
+					if (!fs.existsSync(context.storagePath)) {
+						console.log(context.storagePath);
+						fs.mkdirSync(context.storagePath);
+					}
 
-				let logFile = context.storagePath + '/vscode-languagetool-languageserver.log';
-				let logStream = fs.createWriteStream(logFile, { flags: 'w' });
+					let logFile = context.storagePath + '/vscode-languagetool-languageserver.log';
+					let logStream = fs.createWriteStream(logFile, { flags: 'w' });
 
-				process.stdout.pipe(logStream);
-				process.stderr.pipe(logStream);
+					process.stdout.pipe(logStream);
+					process.stderr.pipe(logStream);
 
-				console.log(`Storing log in '${logFile}'`);
+					console.log(`Storing log in '${logFile}'`);
+				}
+				else {
+					console.log("No storagePath, languagetool-languageserver logging disabled.");
+				}
 			});
 		});
 	};


### PR DESCRIPTION
- Fixes checking of files when no folder was open.  Checking will occur in the new Untitled file since it is plaintext by default.
- Prevents virtual files, including those from the git scm provider, from being checked. (Fixes [#2](https://github.com/adamvoss/vscode-languagetool/issues/2))