### PR TITLE
Add languageTool.enabled configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 *.vsix
 .vscode-test/
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - "./lib/languagetool-languageserver/gradlew --project-dir ./lib/languagetool-languageserver/
   assemble"
 script:
-- vsce package
+- ./node_modules/.bin/vsce package
 deploy:
   provider: releases
   api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+- Adds configuration to make extension opt-in by workspace thanks to [Faustino Aguilar](https://github.com/faustinoaq) ([PR #5](https://github.com/adamvoss/vscode-languagetool/pull/5)). (Work around for [Microsoft/vscode#15611](https://github.com/Microsoft/vscode/issues/15611))
+
 ## 0.0.3
 - Fixes checking of files when no folder was open.
 - Prevents virtual files, including those from the git scm provider, from being checked. (Fixes [#2](https://github.com/adamvoss/vscode-languagetool/issues/2))

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
           "type": "string",
           "default": "en",
           "description": "The language LanguageTool should check against"
+        },
+        "languageTool.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow to enable languageTool on specific workspaces"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,10 +104,15 @@ export function activate(context: ExtensionContext) {
 		}
 	}
 
-	// Create the language client and start the client.
-	let disposable = new LanguageClient('languageTool', 'LanguageTool Client', createServer, clientOptions).start();
+	// Allow to enable languageTool in specific workspaces
+	let config = workspace.getConfiguration('languageTool');
 
-	// Push the disposable to the context's subscriptions so that the 
-	// client can be deactivated on extension deactivation
-	context.subscriptions.push(disposable);
+	if (config['enabled']) {
+		// Create the language client and start the client.
+		let disposable = new LanguageClient('languageTool', 'LanguageTool Client', createServer, clientOptions).start();
+
+		// Push the disposable to the context's subscriptions so that the 
+		// client can be deactivated on extension deactivation
+		context.subscriptions.push(disposable);
+	}
 }


### PR DESCRIPTION
Hi @adamvoss !

I added `languageTool.enabled` to allow enable or disable languageTool in a specific workspace.

I know that you can disable extension using VSCode but the actual behavior forces to enable Always and only disable for some workspace. See [#15611](https://github.com/Microsoft/vscode/issues/15611)

My use case introducing this new configuration is to avoid running the `java` process everytime VSCode starts and only run `java` process when `languageTool.enabled = true` in `settings.json` global or in workspace (default is true).

PD: I compiled `languagetool-languageserver` and tested this changes in my computer. (all ok)
 