### PR TITLE
Update LSP4J and use VSCode API to discover language-support extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 0.0.4
 - Adds configuration to make extension opt-in by workspace thanks to [Faustino Aguilar](https://github.com/faustinoaq) ([PR #5](https://github.com/adamvoss/vscode-languagetool/pull/5)). (Work around for [Microsoft/vscode#15611](https://github.com/Microsoft/vscode/issues/15611))
 - Language-support extensions are now detected through the Visual Studio Code API rather than file-path assumptions.  This is better practice and makes development of the extension easier.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Adds configuration to make extension opt-in by workspace thanks to [Faustino Aguilar](https://github.com/faustinoaq) ([PR #5](https://github.com/adamvoss/vscode-languagetool/pull/5)). (Work around for [Microsoft/vscode#15611](https://github.com/Microsoft/vscode/issues/15611))
+- Language-support extensions are now detected through the Visual Studio Code API rather than file-path assumptions.  This is better practice and makes development of the extension easier.
 
 ## 0.0.3
 - Fixes checking of files when no folder was open.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "LanguageTool grammar checking for Visual Studio Code.",
   "author": "Adam Voss",
   "license": "Apache-2.0",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "adamvoss",
   "repository": {
     "url": "https://github.com/adamvoss/vscode-languagetool"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,18 +5,15 @@ import * as path from 'path';
 import * as net from 'net';
 import * as child_process from "child_process";
 
-import { workspace, Disposable, ExtensionContext } from 'vscode';
+import { extensions, workspace, Disposable, ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, SettingMonitor, StreamInfo } from 'vscode-languageclient';
 
 export function activate(context: ExtensionContext) {
 
-	function discoverExtensions() {
-		const extensionsDir = path.resolve(context.extensionPath, '..')
-
-		const installedExtensions = fs.readdirSync(extensionsDir)
-
-		const extensionRegEx = /^adamvoss\.vscode-languagetool-(?:.*)-(?:.*?)$/
-		return installedExtensions.filter(s => extensionRegEx.test(s))
+	function discoverExtensionPaths() {
+		return extensions.all
+			.filter(x => x.id.startsWith("adamvoss.vscode-languagetool-"))
+			.map(x => x.extensionPath)
 	}
 
 	function buildDesiredClasspath() {
@@ -24,7 +21,7 @@ export function activate(context: ExtensionContext) {
 
 		const joinCharacter = isWindows ? ';' : ':'
 
-		const additionalPaths = discoverExtensions()
+		const additionalPaths = discoverExtensionPaths()
 			.map(p => path.resolve(context.extensionPath, '..', p, 'lib', '*'))
 			.join(joinCharacter);
 


### PR DESCRIPTION
Language-support extensions are now detected through the Visual Studio Code API rather than file-path assumptions.  This is better practice and makes development of the extension easier.