### PR TITLE
Update to LanguageTool 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 3.8.0
+- Update to LanguageTool 3.8. (see [3.8 Release Notes](https://github.com/languagetool-org/languagetool/blob/aa1bef4c0108e25eea7f71bd557b6cc4d9c53c2b/languagetool-standalone/CHANGES.md#38-2017-06-27))
+- Update versioning to reflect LanguageTool versioning.
+- Removed "Preview" flag since no blocker issues have been reported.
+
 ## 0.0.4
 - Adds configuration to make extension opt-in by workspace thanks to [Faustino Aguilar](https://github.com/faustinoaq) ([PR #5](https://github.com/adamvoss/vscode-languagetool/pull/5)). (Work around for [Microsoft/vscode#15611](https://github.com/Microsoft/vscode/issues/15611))
 - Language-support extensions are now detected through the Visual Studio Code API rather than file-path assumptions.  This is better practice and makes development of the extension easier.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This extension contributes the following settings:
 
 * `languageTool.language`: Set to the short code for the language to check.  For supported languages see the [list of languages at LanguageTool.org](https://languagetool.org/languages/).
 
+## Versioning
+
+LanguageTool for Visual Studio code has adopted the versioning of its LanguageTool dependency.  For example, if this extension has version 3.8.0 it is powered by LanguageTool 3.8.  vscode-languagetool 3.8.1, would also use LanguageTool 3.8.  vscode-languagetool 3.9.0 would use LanguageTool 3.9.  **The LanguageTool version of this extension must match the LanguageTool version of your installed language support extensions.**
+
 ## Contributing
 Contributions welcome!  
 This repository uses git submodules.  After cloning, be sure to run `git submodule update --init`.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "vscode-languagetool",
   "displayName": "LanguageTool for Visual Studio Code",
-  "preview": true,
+  "preview": false,
   "description": "LanguageTool grammar checking for Visual Studio Code.",
   "author": "Adam Voss",
   "license": "Apache-2.0",
-  "version": "0.0.4",
+  "version": "3.8.0",
   "publisher": "adamvoss",
   "repository": {
     "url": "https://github.com/adamvoss/vscode-languagetool"


### PR DESCRIPTION
- Update to LanguageTool 3.8. (see [3.8 Release Notes](https://github.com/languagetool-org/languagetool/blob/aa1bef4c0108e25eea7f71bd557b6cc4d9c53c2b/languagetool-standalone/CHANGES.md#38-2017-06-27))
- Update versioning to reflect LanguageTool versioning.
- Removed "Preview" flag since no blocker issues have been reported.